### PR TITLE
update GCP SDK version

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -33,12 +33,12 @@ jobs:
 
       - name: Authenticate for GCP
         id: gcp-auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Authenticate for Docker Hub
         id: docker-auth


### PR DESCRIPTION
Updated GCP Cloud SDK from v0
- uses: google-github-actions/setup-gcloud@v3
